### PR TITLE
fix(notify): fwupd firmware is upgradeable only if upgradeable is set

### DIFF
--- a/notify/src/main.rs
+++ b/notify/src/main.rs
@@ -37,9 +37,8 @@ fn main() {
 
     let event_handler = |event: FirmwareSignal| match event {
         #[cfg(feature = "fwupd")]
-        FirmwareSignal::Fwupd(FwupdSignal { info, .. }) => {
-            if info.latest.as_ref().map_or(false, |latest| latest.as_ref() != info.current.as_ref())
-            {
+        FirmwareSignal::Fwupd(FwupdSignal { upgradeable, .. }) => {
+            if upgradeable {
                 notify();
             }
         }


### PR DESCRIPTION
Use the `upgradeable` field in a fwupd firmware signal to know when
available firmware is actually an upgrade over installed firmware.

Closes #68