### PR TITLE
Support fwupd Update Message

### DIFF
--- a/gtk/src/lib.rs
+++ b/gtk/src/lib.rs
@@ -288,6 +288,7 @@ impl FirmwareWidget {
                     error!("firmware widget error: {}", error_message);
 
                     state.widgets.info_bar.set_visible(true);
+                    state.widgets.info_bar.set_message_type(gtk::MessageType::Error);
                     state.widgets.info_bar_label.set_text(error_message.as_str());
 
                     if let Some(entity) = entity {

--- a/gtk/src/state.rs
+++ b/gtk/src/state.rs
@@ -49,6 +49,9 @@ pub(crate) struct Components {
     /// The latest version associated with a device, if one exists.
     pub(crate) latest: SecondaryMap<Entity, Box<str>>,
 
+    /// A message that should be displayed after a successful upgrade.
+    pub(crate) update_message: SecondaryMap<Entity, Box<str>>,
+
     /// Details about a fwupd device
     #[cfg(feature = "fwupd")]
     pub(crate) fwupd: SparseSecondaryMap<Entity, (FwupdDevice, Vec<FwupdRelease>)>,
@@ -110,6 +113,12 @@ impl State {
                 crate::reboot();
             }
 
+            if let Some(message) = self.components.update_message.remove(entity) {
+                self.widgets.info_bar.set_visible(true);
+                self.widgets.info_bar.set_message_type(gtk::MessageType::Info);
+                self.widgets.info_bar_label.set_text(&*message);
+            }
+
             // Wait 1 second before changing the visibility of the stack.
             let sender = self.ui_sender.clone();
             gtk::timeout_add_seconds(1, move || {
@@ -144,6 +153,10 @@ impl State {
                         let _ = sender.send(Event::Ui(UiEvent::Update(entity)));
                     });
                 }
+            }
+
+            if let Some(update_message) = info.update_message {
+                state.components.update_message.insert(entity, update_message);
             }
 
             let sender = state.ui_sender.clone();

--- a/src/fwupd.rs
+++ b/src/fwupd.rs
@@ -44,6 +44,7 @@ pub fn fwupd_scan<F: Fn(FirmwareSignal)>(fwupd: &FwupdClient, sender: F) {
                             current:          device.version.clone(),
                             latest:           Some(latest.version.clone()),
                             install_duration: latest.install_duration,
+                            update_message:   latest.update_message.clone(),
                         },
                         device,
                         upgradeable,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,9 @@ pub struct FirmwareInfo {
 
     /// The time required for this firmware to be flashed, in seconds.
     pub install_duration: u32,
+
+    /// A message to display after successfully updating.
+    pub update_message: Option<Box<str>>,
 }
 
 /// A collection of all firmware device entities that a frontend is managing.

--- a/src/system76.rs
+++ b/src/system76.rs
@@ -35,6 +35,7 @@ pub fn s76_scan<F: Fn(FirmwareSignal)>(client: &System76Client, sender: F) {
                 changelog.versions.iter().next().expect("empty changelog").bios.clone()
             }),
             install_duration: 1,
+            update_message: None,
         };
 
         sender(FirmwareSignal::S76System(fw, info));
@@ -69,6 +70,7 @@ pub fn s76_scan<F: Fn(FirmwareSignal)>(client: &System76Client, sender: F) {
                     current,
                     latest,
                     install_duration: 15,
+                    update_message: None,
                 };
 
                 Some(FirmwareSignal::ThelioIo(fw, digest))


### PR DESCRIPTION
Vendors may associate an update message with a release, which is to be displayed after the device has been successfully updated. We will display that message in our info bar, which was previously only being used to display error messages.

Implements https://github.com/pop-os/fwupd-dbus/issues/2