### PR TITLE
Handle string array for changelog description

### DIFF
--- a/gtk/src/dialogs/system76.rs
+++ b/gtk/src/dialogs/system76.rs
@@ -18,7 +18,17 @@ pub struct System76Dialog<'a> {
 impl<'a> System76Dialog<'a> {
     pub fn run(self) {
         let log_entries = self.changelog.versions.iter().map(|version| {
-            (version.bios.as_ref(), version.description.as_ref().map_or("", |desc| desc.as_ref()))
+            let description = if let Some(desc) = version.description {
+                if desc.is_string() {
+                    desc.as_ref()
+                } else {
+                    desc.join("\n")
+                }
+            } else {
+                ""
+            };
+
+            (version.bios.as_ref(), description)
         });
 
         let dialog = FirmwareUpdateDialog::new(self.latest, log_entries, self.has_battery);


### PR DESCRIPTION
Changelog entries have been updated to support an array of strings
in addition to a single string for the description.

Ref: pop-os/system76-firmware#46