### PR TITLE
fix: Add .shlibs file, and update version to 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firmware-manager"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Michael Aaron Murphy <mmstick@pm.me>"]
 edition = "2018"
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+firmware-manager (0.1.2) groovy; urgency=medium
+
+  * Include SONAME in library
+
+ -- Ian Douglas Scott <idscott@system76.com>  Tue, 01 Dec 2020 09:18:49 -0800
+
 firmware-manager (0.1.1) bionic; urgency=medium
 
   * 0.1.1 release.

--- a/debian/libfirmware-manager.shlibs
+++ b/debian/libfirmware-manager.shlibs
@@ -1,0 +1,1 @@
+libfirmware_manager 0 libfirmware-manager (>= 0.1.2)

--- a/gtk/Cargo.toml.in
+++ b/gtk/Cargo.toml.in
@@ -1,6 +1,6 @@
 [package]
 name = "firmware-manager-gtk"
-version = "0.1.0"
+version = "0.1.2"
 authors = ["Michael Aaron Murphy <mmstick@pm.me>"]
 edition = "2018"
 

--- a/gtk/ffi/Cargo.toml.in
+++ b/gtk/ffi/Cargo.toml.in
@@ -1,6 +1,6 @@
 [package]
 name = "firmware-manager-gtk-ffi"
-version = "0.1.0"
+version = "0.1.2"
 authors = ["Michael Aaron Murphy <mmstick@pm.me>"]
 edition = "2018"
 


### PR DESCRIPTION
It seems the gnome-control-center binary ends up linking against the SONAME symlink, so it should depend on a version that includes it. With this, `dh_shlibdeps` generates such a dependency. This, or `.symbols`, is also required by the debian policy manual, so it's probably best to tend to follow the conventions for `.deb` packages.

This should not change the behavior of anything other than new packages built against this library.

Building the 3.38.2 branch of gnome-control-center with `fakeroot make -f debian/rules binary` when this version is installed resulted in a generated dependency with the version requirement from `.shlibs`.