### PR TITLE
gtk: Trim changelog descriptions

### DIFF
--- a/gtk/src/changelog.rs
+++ b/gtk/src/changelog.rs
@@ -30,7 +30,7 @@ where
         let markdown = if entry.as_ref().is_empty() {
             fl!("changelog-unavailable")
         } else {
-            html2runes::markdown::convert_string(entry.as_ref())
+            html2runes::markdown::convert_string(entry.as_ref()).trim().to_string()
         };
 
         // NOTE: If we don't set a max width in chars, the label resizes its parent.


### PR DESCRIPTION
html2runes unconditionally adds newlines before/after elements. This creates a large blank space in the UI if the last thing in the changelog description is a list.

Ref: system76/firmware#407