### PR TITLE
gtk: Show release date for fwupd updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +528,20 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "clap"
@@ -1020,6 +1049,7 @@ version = "0.1.5"
 dependencies = [
  "better-panic",
  "cascade",
+ "chrono",
  "clap 4.4.18",
  "fern",
  "firmware-manager",
@@ -1696,7 +1726,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -1784,6 +1814,29 @@ dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2174,6 +2227,15 @@ dependencies = [
  "log",
  "mac-notification-sys",
  "tauri-winrt-notification",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/gtk/Cargo.toml
+++ b/gtk/Cargo.toml
@@ -12,6 +12,7 @@ system76 = []
 [dependencies]
 better-panic = "0.3.0"
 cascade = "1.0.1"
+chrono = "0.4"
 clap = "4.4.18"
 fern = "0.6.2"
 firmware-manager = { path = "../" }

--- a/gtk/src/changelog.rs
+++ b/gtk/src/changelog.rs
@@ -1,5 +1,6 @@
 use crate::fl;
 use gtk::prelude::*;
+use chrono::{LocalResult, TimeZone, Utc};
 
 pub fn generate_widget_none() -> gtk::Box {
     gtk::Box::builder()
@@ -17,7 +18,7 @@ pub fn generate_widget_none() -> gtk::Box {
 pub fn generate_widget<I, S>(changelog: I) -> gtk::Box
 where
     S: AsRef<str>,
-    I: Iterator<Item = (S, S, S)>,
+    I: Iterator<Item = (S, u64, S)>,
 {
     let changelog_entries = cascade! {
         gtk::Box::new(gtk::Orientation::Vertical, 12);
@@ -38,10 +39,11 @@ where
 
         const PADDING: i32 = 48;
 
-        let version_label = if !date.as_ref().is_empty() {
-            format!("<b>{}</b> ({})", version.as_ref(), date.as_ref())
-        } else {
-            format!("<b>{}</b>", version.as_ref())
+        let version_label = match Utc.timestamp_opt(date as i64, 0) {
+            LocalResult::Single(dt) => {
+                format!("<b>{}</b> ({})", version.as_ref(), dt.format("%Y-%m-%d"))
+            }
+            _ => format!("<b>{}</b>", version.as_ref()),
         };
 
         let version = gtk::Label::builder()

--- a/gtk/src/dialogs/fwupd.rs
+++ b/gtk/src/dialogs/fwupd.rs
@@ -22,8 +22,7 @@ impl<'a> FwupdDialog<'a> {
             .releases
             .iter()
             .rev()
-            // TODO: Add release date
-            .map(|release| (release.version.as_ref(), "", release.description.as_ref()));
+            .map(|release| (release.version.as_ref(), release.created, release.description.as_ref()));
 
         let response = if self.needs_reboot {
             let dialog = FirmwareUpdateDialog::new(self.latest, log_entries, self.has_battery);

--- a/gtk/src/dialogs/mod.rs
+++ b/gtk/src/dialogs/mod.rs
@@ -15,7 +15,7 @@ use gtk::prelude::*;
 pub struct FirmwareUpdateDialog(gtk::Dialog);
 
 impl FirmwareUpdateDialog {
-    pub fn new<S: AsRef<str>, I: Iterator<Item = (S, S, S)>>(
+    pub fn new<S: AsRef<str>, I: Iterator<Item = (S, u64, S)>>(
         version: &str,
         changelog: I,
         has_battery: bool,

--- a/gtk/src/dialogs/system76.rs
+++ b/gtk/src/dialogs/system76.rs
@@ -3,6 +3,7 @@ use crate::widgets::DeviceWidget;
 use firmware_manager::{Entity, FirmwareEvent, System76Changelog, System76Digest};
 use gtk::prelude::*;
 use std::sync::mpsc::Sender;
+use chrono::NaiveDateTime;
 
 /// An instance of the firmware update dialog specific to system76-managed system devices.
 pub struct System76Dialog<'a> {
@@ -18,7 +19,11 @@ pub struct System76Dialog<'a> {
 impl<'a> System76Dialog<'a> {
     pub fn run(self) {
         let log_entries = self.changelog.versions.iter().map(|version| {
-            (version.bios.as_ref(), version.date.as_ref(), version.description.as_ref())
+            let date = NaiveDateTime::parse_from_str(&version.date, "%Y-%m-%d")
+                .unwrap_or_default()
+                .timestamp();
+
+            (version.bios.as_ref(), date as u64, version.description.as_ref())
         });
 
         let dialog = FirmwareUpdateDialog::new(self.latest, log_entries, self.has_battery);


### PR DESCRIPTION
fwupd stores the release date as an unsigned 64-bit Unix timestamp, whereas system76-firmware stores it as a string. Convert the System76 value to a timestamp to match fwupd.

Ref: https://github.com/pop-os/firmware-manager/pull/127