### PR TITLE
fix: set the correct return type in `emit_by_name` to prevent `panic!` after few fast clicks on firmware-manager items

### DIFF
--- a/gtk/src/views/devices.rs
+++ b/gtk/src/views/devices.rs
@@ -33,7 +33,7 @@ impl DevicesView {
                     .and_then(|w| w.children().into_iter().next());
 
                 if let Some(widget) = widget {
-                    let _ = widget.emit_by_name::<()>("button_press_event", &[&gdk::Event::new(gdk::EventType::ButtonPress)]);
+                    let _ = widget.emit_by_name::<bool>("button_press_event", &[&gdk::Event::new(gdk::EventType::ButtonPress)]);
                 }
             });
         };


### PR DESCRIPTION
Closes #130