### PR TITLE
fix: Set correct return type for fwupd section dropdown

### DIFF
--- a/gtk/src/views/devices.rs
+++ b/gtk/src/views/devices.rs
@@ -49,7 +49,7 @@ impl DevicesView {
                     .and_then(|w| w.children().into_iter().next());
 
                 if let Some(widget) = widget {
-                    let _ = widget.emit_by_name::<()>("button_press_event", &[&gdk::Event::new(gdk::EventType::ButtonPress)]);
+                    let _ = widget.emit_by_name::<bool>("button_press_event", &[&gdk::Event::new(gdk::EventType::ButtonPress)]);
                 }
             });
             ..connect_key_press_event(move |listbox, event| {


### PR DESCRIPTION
I've just copied the change that https://github.com/pop-os/firmware-manager/pull/152 made to the system76-firmware dropdown and applied it to the fwupd dropdown. Opening the Firmware settings page and clicking around on the two dropdowns, I believe this further reduces (or may eliminate) the crashes we've gotten used to seeing.

Tested on a galp7 with a launch_1 plugged in.