### PR TITLE
feat: enable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,6 @@ tokio = { version = "1.35.1", features = ["rt"] }
 tokio-udev = "0.9.1"
 users = "0.11.0"
 xdg = "2.5.2"
+
+[profile.release]
+lto = "fat"


### PR DESCRIPTION
Hi!

I started a discussion about enabling Link-Time Optimization (LTO) across all pop!_os projects to improve their general performance (more compiler optimizations can be done with LTO) and the binary size reduction (LTO usually leads to measurable binary size improvements) here - https://github.com/pop-os/pop/discussions/3386 . In https://github.com/pop-os/pop/discussions/3386#discussioncomment-10909426 was proposed creating PRs into repos with enabling LTO - it's such a PR!

As a reference, I used the `cosmic-comp` Release [profile](https://github.com/pop-os/cosmic-comp/blob/master/Cargo.toml#L116).

I have made quick local tests (Fedora 40): the binary `firmware-manager-gtk` size from enabled `lto = "fat"` was dropped from 20 Mib to 14 Mib.